### PR TITLE
fix: follow cwd symlink on windows

### DIFF
--- a/src/getAppRootPath.ts
+++ b/src/getAppRootPath.ts
@@ -1,11 +1,11 @@
 import { join, resolve } from "./path"
-import process from "process"
 import { existsSync } from "fs-extra"
+import { realpathCwd } from "./realpathCwd"
 
 export const getAppRootPath = (): string => {
-  let cwd = process.cwd()
+  let cwd = realpathCwd().replace("\\", "/")
   while (!existsSync(join(cwd, "package.json"))) {
-    const up = resolve(cwd, "../")
+    const up = resolve(cwd, "../").replace("\\", "/")
     if (up === cwd) {
       throw new Error("no package.json found for this project")
     }

--- a/src/getAppRootPath.ts
+++ b/src/getAppRootPath.ts
@@ -3,9 +3,9 @@ import { existsSync } from "fs-extra"
 import { realpathCwd } from "./realpathCwd"
 
 export const getAppRootPath = (): string => {
-  let cwd = realpathCwd().replace("\\", "/")
+  let cwd = realpathCwd().replace(/\\/g, "/")
   while (!existsSync(join(cwd, "package.json"))) {
-    const up = resolve(cwd, "../").replace("\\", "/")
+    const up = resolve(cwd, "../").replace(/\\/g, "/")
     if (up === cwd) {
       throw new Error("no package.json found for this project")
     }

--- a/src/getPackageResolution.ts
+++ b/src/getPackageResolution.ts
@@ -5,6 +5,7 @@ import { readFileSync, existsSync } from "fs-extra"
 import { parse as parseYarnLockFile } from "@yarnpkg/lockfile"
 import findYarnWorkspaceRoot from "find-yarn-workspace-root"
 import { getPackageVersion } from "./getPackageVersion"
+import { realpathCwd } from "./realpathCwd"
 //import { execSync } from "child_process"
 
 //const isVerbose = global.patchPackageIsVerbose
@@ -261,9 +262,9 @@ if (require.main === module) {
   }
   console.log(
     getPackageResolution({
-      appPath: process.cwd(),
+      appPath: realpathCwd(),
       packageDetails,
-      packageManager: detectPackageManager(process.cwd(), null),
+      packageManager: detectPackageManager(realpathCwd(), null),
       appPackageJson: {}, // TODO?
     }),
   )

--- a/src/patch/read.test.ts
+++ b/src/patch/read.test.ts
@@ -7,6 +7,9 @@ const removeAnsiCodes = (s: string) =>
     "",
   )
 
+jest.mock("fs", () => ({
+  realpathSync: jest.fn((path)=>path),
+}))
 jest.mock("fs-extra", () => ({
   readFileSync: jest.fn(),
 }))

--- a/src/patch/read.ts
+++ b/src/patch/read.ts
@@ -4,6 +4,7 @@ import { relative, resolve } from "../path"
 import { normalize } from "path"
 import { PackageDetails } from "../PackageDetails"
 import { parsePatchFile, PatchFilePart } from "./parse"
+import { realpathCwd } from "../realpathCwd"
 
 export function readPatch({
   patchFilePath,
@@ -19,7 +20,7 @@ export function readPatch({
   } catch (e) {
     const fixupSteps: string[] = []
     const relativePatchFilePath = normalize(
-      relative(process.cwd(), patchFilePath),
+      relative(realpathCwd(), patchFilePath),
     )
     const patchBaseDir = relativePatchFilePath.slice(
       0,
@@ -36,7 +37,7 @@ export function readPatch({
     fixupSteps.push(`npx patch-package ${packageDetails.pathSpecifier}`)
     if (patchBaseDir) {
       fixupSteps.push(
-        `cd ${relative(resolve(process.cwd(), patchBaseDir), process.cwd())}`,
+        `cd ${relative(resolve(realpathCwd(), patchBaseDir), realpathCwd())}`,
       )
     }
 

--- a/src/realpathCwd.ts
+++ b/src/realpathCwd.ts
@@ -1,0 +1,6 @@
+import fs from "fs"
+import process from "process"
+
+export const realpathCwd = (): string => {
+  return fs.realpathSync(process.cwd())
+}


### PR DESCRIPTION
Node's `process.cwd()` has different behaviour between unix OS's and Windows when the cwd is inside a symlink. This PR fixes this inconsistency by calling node's `fs.realpathSync` to follow the directory symlink and simulate unix's behaviour on Windows.

This incosistency causes patch-package to fail on Windows when it runs on a postinstall of a workspace package since yarn (and possibly other package managers as well) use symlinks to hoist packages to the root node_modules.

This PR also fixes the path comparison on the `getAppRootPath`, since Windows can have both `\` and `/` path separators.